### PR TITLE
README: added prerequisites to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Install docker compose
 
 ### Start Integration Tests
 
+:information_source: Make sure you have `PYTHONPATH` set (e.g. `export PYTHONPATH=$(pwd)`), otherwise you could receive `ModuleNotFoundError`
+
 Run pytest
 `pytest`
 


### PR DESCRIPTION
`PYTHONPATH` is the default search path for module files. Could be not defined, especially if you use [virtualenvs](https://virtualenv.pypa.io/en/stable/). 

errors may appear:

```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/chuck/.virtualenvs/qrl_tests/lib/python3.6/site-packages/_pytest/config.py", line 366, in _importconftest
    mod = conftestpath.pyimport()
  File "/Users/chuck/.virtualenvs/qrl_tests/lib/python3.6/site-packages/py/_path/local.py", line 668, in pyimport
    __import__(modname)
  File "/Users/chuck/.virtualenvs/qrl_tests/lib/python3.6/site-packages/_pytest/assertion/rewrite.py", line 213, in load_module
    py.builtin.exec_(co, mod.__dict__)
  File "/Users/chuck/workspace/qrl/integration_tests/tests/conftest.py", line 6, in <module>
    from tests.helpers.nodes_synchronize import wait_for_sync
ModuleNotFoundError: No module named 'tests'
ERROR: could not load /Users/chuck/workspace/qrl/integration_tests/tests/conftest.py
```