### PR TITLE
Fix Integration Test

### DIFF
--- a/mocknet/mocknet.py
+++ b/mocknet/mocknet.py
@@ -157,7 +157,7 @@ class MockNet(object):
 
             for node_idx in range(self.node_count):
                 self.nodes.append(self.pool.submit(self.start_node, node_idx, self.stop_event))
-                sleep(2)  # Delay before starting each node, so that nodes can connect to each other
+                sleep(0.05)  # Delay before starting each node, so that nodes can connect to each other
 
             try:
                 result = test_future.result(self.timeout_secs)


### PR DESCRIPTION
test_launch_log_nodes having max running_time of 10 seconds and total numbers of nodes to spawn is 10. While each node is spawn after 2 seconds, needed atleast 18 seconds to spawn the nodes. Due to this mismatch of time, the integration test stucks at Mocknet Tests. This PR has reduced node spawn delay from 2 seconds to 0.05 seconds.