### PR TITLE
Limiting package.json to most recent minor version instead of major version

### DIFF
--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -9,11 +9,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chai": "^4.1.2",
-    "fs-extra": "^5.0.0",
-    "grpc": "^1.9.1",
-    "mocha": "^5.0.1",
-    "qrllib": "^0.8.9",
-    "temp": "^0.8.3"
+    "chai": "~4.1.2",
+    "fs-extra": "~5.0.0",
+    "grpc": "~1.9.1",
+    "mocha": "~5.0.1",
+    "qrllib": "~0.8.9",
+    "temp": "~0.8.3"
   }
 }


### PR DESCRIPTION
Fix for JS test